### PR TITLE
Enable useStrictCSP for cssInjectedByJsPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,6 @@ To localize UI labels, put this object to your i18n dictionary under the `tools`
 
 See more instructions about Editor.js internationalization here: [https://editorjs.io/internationalization](https://editorjs.io/internationalization)
 
-## Supports CSP out of the box
+## CSP support
 
-Adds a nonce to injected style tags based on [`<meta property="csp-nonce" content={{ nonce }} />`](https://github.com/marco-prontera/vite-plugin-css-injected-by-js#usestrictcsp-boolean) being present in your document head.
+If you're using Content Security Policy (CSP) pass a `nonce` via [`<meta property="csp-nonce" content={{ nonce }} />`](https://github.com/marco-prontera/vite-plugin-css-injected-by-js#usestrictcsp-boolean) in your document head.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/list",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "keywords": [
     "codex editor",
     "list",

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,5 +19,5 @@ export default {
     VERSION: JSON.stringify(VERSION),
   },
 
-  plugins: [cssInjectedByJsPlugin()],
+  plugins: [cssInjectedByJsPlugin({useStrictCSP: true})],
 };


### PR DESCRIPTION
Enables useStrictCSP when injecting styles. See https://github.com/marco-prontera/vite-plugin-css-injected-by-js#usestrictcsp-boolean

Does not throw any errors if meta property is not present

```useStrictCSP ? `elementStyle.nonce = document.head.querySelector('meta[property=csp-nonce]')?.content;` : ''```

Updated README to reflect the out of the box support